### PR TITLE
Remove promises and callback support

### DIFF
--- a/lib/Jexl.js
+++ b/lib/Jexl.js
@@ -113,26 +113,10 @@ Jexl.prototype.getTransform = function(name) {
  *      a '.catch' attached to it in order to pass the error to the callback.
  */
 Jexl.prototype.eval = function(expression, context, cb) {
-  if (typeof context === 'function') {
-    cb = context;
+  if (!context)
     context = {};
-  }
-  else if (!context)
-    context = {};
-  var valPromise = this._eval(expression, context);
-  if (cb) {
-    // setTimeout is used for the callback to break out of the Promise's
-    // try/catch in case the callback throws.
-    var called = false;
-    return valPromise.then(function(val) {
-      called = true;
-      setTimeout(cb.bind(null, null, val), 0);
-    }).catch(function(err) {
-      if (!called)
-        setTimeout(cb.bind(null, err), 0);
-    });
-  }
-  return valPromise;
+
+  return this._eval(expression, context);
 };
 
 /**
@@ -181,19 +165,15 @@ Jexl.prototype._eval = function(exp, context) {
 
   var cachedExpressionTree = this._getParserCache(exp);
   if (cachedExpressionTree) {
-    return Promise.resolve().then(function() {
-      return evaluator.eval(cachedExpressionTree);
-    });
+    return evaluator.eval(cachedExpressionTree);
   }
 
   var parser = new Parser(grammar);
 
-  return Promise.resolve().then(function() {
-    parser.addTokens(self._getLexer().tokenize(exp));
-    var expressionTree = parser.complete();
-    self._setParserCache(exp, expressionTree);
-    return evaluator.eval(expressionTree);
-  });
+  parser.addTokens(self._getLexer().tokenize(exp));
+  var expressionTree = parser.complete();
+  self._setParserCache(exp, expressionTree);
+  return evaluator.eval(expressionTree);
 };
 
 /**

--- a/lib/Jexl.js
+++ b/lib/Jexl.js
@@ -34,8 +34,7 @@ function Jexl() {
  * @param {number} precedence The operator's precedence
  * @param {function} fn A function to run to calculate the result. The function
  *      will be called with two arguments: left and right, denoting the values
- *      on either side of the operator. It should return either the resulting
- *      value, or a Promise that resolves with the resulting value.
+ *      on either side of the operator. The function returns the resulting value.
  */
 Jexl.prototype.addBinaryOp = function(operator, precedence, fn) {
   this._addGrammarElement(operator, {
@@ -51,8 +50,7 @@ Jexl.prototype.addBinaryOp = function(operator, precedence, fn) {
  * @param {string} operator The operator string to be added
  * @param {function} fn A function to run to calculate the result. The function
  *      will be called with one argument: the literal value to the right of the
- *      operator. It should return either the resulting value, or a Promise
- *      that resolves with the resulting value.
+ *      operator. The function returns the resulting value.
  */
 Jexl.prototype.addUnaryOp = function(operator, fn) {
   this._addGrammarElement(operator, {
@@ -104,15 +102,9 @@ Jexl.prototype.getTransform = function(name) {
  * @param {string} expression The Jexl expression to be evaluated
  * @param {Object} [context] A mapping of variables to values, which will be
  *      made accessible to the Jexl expression when evaluating it
- * @param {function} [cb] An optional callback function to be executed when
- *      evaluation is complete.  It will be supplied with two arguments:
- *          - {Error|null} err: Present if an error occurred
- *          - {*} result: The result of the evaluation
- * @returns {Promise<*>} resolves with the result of the evaluation.  Note that
- *      if a callback is supplied, the returned promise will already have
- *      a '.catch' attached to it in order to pass the error to the callback.
+ * @returns {*} returns the result of the evaluation.
  */
-Jexl.prototype.eval = function(expression, context, cb) {
+Jexl.prototype.eval = function(expression, context) {
   if (!context)
     context = {};
 
@@ -155,7 +147,7 @@ Jexl.prototype._addGrammarElement = function(str, obj) {
  * @param {string} exp The Jexl expression to be evaluated
  * @param {Object} [context] A mapping of variables to values, which will be
  *      made accessible to the Jexl expression when evaluating it
- * @returns {Promise<*>} resolves with the result of the evaluation.
+ * @returns {*} returns the result of the evaluation.
  * @private
  */
 Jexl.prototype._eval = function(exp, context) {

--- a/lib/evaluator/Evaluator.js
+++ b/lib/evaluator/Evaluator.js
@@ -48,10 +48,7 @@ var Evaluator = function(grammar, transforms, context, relativeContext) {
  * @returns {Promise<*>} resolves with the resulting value of the expression.
  */
 Evaluator.prototype.eval = function(ast) {
-  var self = this;
-  return Promise.resolve().then(function() {
-    return handlers[ast.type].call(self, ast);
-  });
+  return handlers[ast.type].call(this, ast);
 };
 
 /**
@@ -62,9 +59,9 @@ Evaluator.prototype.eval = function(ast) {
  * @returns {Promise<Array<{}>>} resolves with the result array
  */
 Evaluator.prototype.evalArray = function(arr) {
-  return Promise.all(arr.map(function(elem) {
+  return arr.map(function(elem) {
     return this.eval(elem);
-  }, this));
+  }, this);
 };
 
 /**
@@ -81,12 +78,12 @@ Evaluator.prototype.evalMap = function(map) {
   var asts = keys.map(function(key) {
     return this.eval(map[key]);
   }, this);
-  return Promise.all(asts).then(function(vals) {
-    vals.forEach(function(val, idx) {
-      result[keys[idx]] = val;
-    });
-    return result;
+
+  asts.forEach(function(val, idx) {
+    result[keys[idx]] = val;
   });
+
+  return result;
 };
 
 /**
@@ -109,22 +106,19 @@ Evaluator.prototype.evalMap = function(map) {
  * @private
  */
 Evaluator.prototype._filterRelative = function(subject, expr) {
-  var promises = [];
   if (!Array.isArray(subject))
     subject = [subject];
-  subject.forEach(function(elem) {
-    var evalInst = new Evaluator(this._grammar, this._transforms,
-      this._context, elem);
-    promises.push(evalInst.eval(expr));
+  var values = subject.map(function(elem) {
+    var evalInst = new Evaluator(this._grammar, this._transforms, this._context, elem);
+    return evalInst.eval(expr)
   }, this);
-  return Promise.all(promises).then(function(values) {
-    var results = [];
-    values.forEach(function(value, idx) {
-      if (value)
-        results.push(subject[idx]);
-    });
-    return results;
+
+  var results = [];
+  values.forEach(function(value, idx) {
+    if (value)
+      results.push(subject[idx]);
   });
+  return results;
 };
 
 /**
@@ -143,11 +137,10 @@ Evaluator.prototype._filterRelative = function(subject, expr) {
  * @private
  */
 Evaluator.prototype._filterStatic = function(subject, expr) {
-  return this.eval(expr).then(function(res) {
-    if (typeof res === 'boolean')
-      return res ? subject : undefined;
-    return subject[res];
-  });
+  var res = this.eval(expr);
+  if (typeof res === 'boolean')
+    return res ? subject : undefined;
+  return subject[res];
 };
 
 module.exports = Evaluator;

--- a/lib/evaluator/Evaluator.js
+++ b/lib/evaluator/Evaluator.js
@@ -45,7 +45,7 @@ var Evaluator = function(grammar, transforms, context, relativeContext) {
 /**
  * Evaluates an expression tree within the configured context.
  * @param {{}} ast An expression tree object
- * @returns {Promise<*>} resolves with the resulting value of the expression.
+ * @returns {*} returns the resulting value of the expression.
  */
 Evaluator.prototype.eval = function(ast) {
   return handlers[ast.type].call(this, ast);
@@ -56,7 +56,7 @@ Evaluator.prototype.eval = function(ast) {
  * response as an array with the resulting values at the same indexes as their
  * originating expressions.
  * @param {Array<string>} arr An array of expression strings to be evaluated
- * @returns {Promise<Array<{}>>} resolves with the result array
+ * @returns {Array<{}>} returns the result array
  */
 Evaluator.prototype.evalArray = function(arr) {
   return arr.map(function(elem) {
@@ -70,7 +70,7 @@ Evaluator.prototype.evalArray = function(arr) {
  * as their value.
  * @param {{}} map A map of expression names to expression trees to be
  *      evaluated
- * @returns {Promise<{}>} resolves with the result map.
+ * @returns {{}} returns the result map.
  */
 Evaluator.prototype.evalMap = function(map) {
   var keys = Object.keys(map),
@@ -101,7 +101,7 @@ Evaluator.prototype.evalMap = function(map) {
  * @param {{}} expr The expression tree to run against each subject. If the
  *      tree evaluates to a truthy result, then the value will be included in
  *      the returned array; otherwise, it will be eliminated.
- * @returns {Promise<Array>} resolves with an array of values that passed the
+ * @returns {Array} returns an array of values that passed the
  *      expression filter.
  * @private
  */
@@ -133,7 +133,7 @@ Evaluator.prototype._filterRelative = function(subject, expr) {
  *      Object (for which the expression would generally resolve to a string
  *      indicating a property name)
  * @param {{}} expr The expression tree to run against the subject
- * @returns {Promise<*>} resolves with the value of the drill-down.
+ * @returns {*} returns the value of the drill-down.
  * @private
  */
 Evaluator.prototype._filterStatic = function(subject, expr) {

--- a/lib/evaluator/handlers.js
+++ b/lib/evaluator/handlers.js
@@ -25,13 +25,7 @@ exports.ArrayLiteral = function(ast) {
  * @private
  */
 exports.BinaryExpression = function(ast) {
-  var self = this;
-  return Promise.all([
-    this.eval(ast.left),
-    this.eval(ast.right)
-  ]).then(function(arr) {
-    return self._grammar[ast.operator].eval(arr[0], arr[1]);
-  });
+  return this._grammar[ast.operator].eval(this.eval(ast.left), this.eval(ast.right));
 };
 
 /**
@@ -45,15 +39,13 @@ exports.BinaryExpression = function(ast) {
  * @private
  */
 exports.ConditionalExpression = function(ast) {
-  var self = this;
-  return this.eval(ast.test).then(function(res) {
-    if (res) {
-      if (ast.consequent)
-        return self.eval(ast.consequent);
-      return res;
-    }
-    return self.eval(ast.alternate);
-  });
+  var res = this.eval(ast.test);
+  if (res) {
+    if (ast.consequent)
+      return this.eval(ast.consequent);
+    return res;
+  }
+  return this.eval(ast.alternate);
 };
 
 /**
@@ -65,12 +57,10 @@ exports.ConditionalExpression = function(ast) {
  * @private
  */
 exports.FilterExpression = function(ast) {
-  var self = this;
-  return this.eval(ast.subject).then(function(subject) {
-    if (ast.relative)
-      return self._filterRelative(subject, ast.expr);
-    return self._filterStatic(subject, ast.expr);
-  });
+  var subject = this.eval(ast.subject);
+  if (ast.relative)
+    return this._filterRelative(subject, ast.expr);
+  return this._filterStatic(subject, ast.expr);
 };
 
 /**
@@ -85,13 +75,12 @@ exports.FilterExpression = function(ast) {
  */
 exports.Identifier = function(ast) {
   if (ast.from) {
-    return this.eval(ast.from).then(function(context) {
-      if (context === undefined)
-        return undefined;
-      if (Array.isArray(context))
-        context = context[0];
-      return context[ast.value];
-    });
+    var context = this.eval(ast.from);
+    if (context === undefined)
+      return undefined;
+    if (Array.isArray(context))
+      context = context[0];
+    return context[ast.value];
   }
   else {
     return ast.relative ? this._relContext[ast.value] :
@@ -135,12 +124,11 @@ exports.Transform = function(ast) {
   var transform = this._transforms[ast.name];
   if (!transform)
     throw new Error("Transform '" + ast.name + "' is not defined.");
-  return Promise.all([
-    this.eval(ast.subject),
-    this.evalArray(ast.args || [])
-  ]).then(function(arr) {
-    return transform.apply(null, [arr[0]].concat(arr[1]));
-  });
+
+  var subject = this.eval(ast.subject);
+  var args = this.evalArray(ast.args || []);
+
+  return transform.apply(null, [subject].concat(args));
 };
 
 /**
@@ -152,8 +140,5 @@ exports.Transform = function(ast) {
  * @constructor
  */
 exports.UnaryExpression = function(ast) {
-  var self = this;
-  return this.eval(ast.right).then(function(right) {
-    return self._grammar[ast.operator].eval(right);
-  });
+  return this._grammar[ast.operator].eval(this.eval(ast.right));
 };

--- a/lib/evaluator/handlers.js
+++ b/lib/evaluator/handlers.js
@@ -8,7 +8,7 @@
  * independently run through the evaluator.
  * @param {{type: 'ObjectLiteral', value: <{}>}} ast An expression tree with an
  *      ObjectLiteral as the top node
- * @returns {Promise.<[]>} resolves to a map contained evaluated values.
+ * @returns {[]} returns a map contained evaluated values.
  * @private
  */
 exports.ArrayLiteral = function(ast) {
@@ -21,7 +21,7 @@ exports.ArrayLiteral = function(ast) {
  * @param {{type: 'BinaryExpression', operator: <string>, left: {},
  *      right: {}}} ast An expression tree with a BinaryExpression as the top
  *      node
- * @returns {Promise<*>} resolves with the value of the BinaryExpression.
+ * @returns {*} returns the value of the BinaryExpression.
  * @private
  */
 exports.BinaryExpression = function(ast) {
@@ -53,7 +53,7 @@ exports.ConditionalExpression = function(ast) {
  * @param {{type: 'FilterExpression', relative: <boolean>, expr: {},
  *      subject: {}}} ast An expression tree with a FilterExpression as the top
  *      node
- * @returns {Promise<*>} resolves with the value of the FilterExpression.
+ * @returns {*} returns the value of the FilterExpression.
  * @private
  */
 exports.FilterExpression = function(ast) {
@@ -69,8 +69,7 @@ exports.FilterExpression = function(ast) {
  * constructed.
  * @param {{type: 'Identifier', value: <string>, [from]: {}}} ast An expression
  *      tree with an Identifier as the top node
- * @returns {Promise<*>|*} either the identifier's value, or a Promise that
- *      will resolve with the identifier's value.
+ * @returns {*} returns the identifier's value.
  * @private
  */
 exports.Identifier = function(ast) {
@@ -104,7 +103,7 @@ exports.Literal = function(ast) {
  * independently run through the evaluator.
  * @param {{type: 'ObjectLiteral', value: <{}>}} ast An expression tree with an
  *      ObjectLiteral as the top node
- * @returns {Promise<{}>} resolves to a map contained evaluated values.
+ * @returns {{}} returns a map contained evaluated values.
  * @private
  */
 exports.ObjectLiteral = function(ast) {
@@ -116,8 +115,7 @@ exports.ObjectLiteral = function(ast) {
  * to the subject value.
  * @param {{type: 'Transform', name: <string>, subject: {}}} ast An
  *      expression tree with a Transform as the top node
- * @returns {Promise<*>|*} the value of the transformation, or a Promise that
- *      will resolve with the transformed value.
+ * @returns {*} returns the value of the transformation.
  * @private
  */
 exports.Transform = function(ast) {
@@ -136,7 +134,7 @@ exports.Transform = function(ast) {
  * operator's eval function.
  * @param {{type: 'UnaryExpression', operator: <string>, right: {}}} ast An
  *      expression tree with a UnaryExpression as the top node
- * @returns {Promise<*>} resolves with the value of the UnaryExpression.
+ * @returns {*} returns the value of the UnaryExpression.
  * @constructor
  */
 exports.UnaryExpression = function(ast) {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   "devDependencies": {
     "browserify": "=9.0.3",
     "chai": "^2.0.0",
-    "chai-as-promised": "^4.2.0",
     "gulp": "=3.8.11",
     "gulp-istanbul": "^0.6.0",
     "gulp-istanbul-enforcer": "^1.0.3",

--- a/test/evaluator/Evaluator.js
+++ b/test/evaluator/Evaluator.js
@@ -4,14 +4,12 @@
  */
 
 var chai = require('chai'),
-  chaiAsPromised = require('chai-as-promised'),
   should = require('chai').should(),
+  expect = require('chai').expect,
   Lexer = require('../../lib/Lexer'),
   Parser = require('../../lib/parser/Parser'),
   Evaluator = require('../../lib/evaluator/Evaluator'),
   grammar = require('../../lib/grammar').elements;
-
-chai.use(chaiAsPromised);
 
 var lexer = new Lexer(grammar);
 
@@ -24,31 +22,28 @@ function toTree(exp) {
 describe('Evaluator', function() {
   it('should evaluate an arithmetic expression', function() {
     var e = new Evaluator(grammar);
-    return e.eval(toTree('(2 + 3) * 4')).should.become(20);
+    e.eval(toTree('(2 + 3) * 4')).should.equal(20);
   });
   it('should evaluate a string concat', function() {
     var e = new Evaluator(grammar);
-    return e.eval(toTree('"Hello" + (4+4) + "Wo\\"rld"'))
-      .should.become('Hello8Wo"rld');
+    e.eval(toTree('"Hello" + (4+4) + "Wo\\"rld"')).should.equal('Hello8Wo"rld');
   });
   it('should evaluate a true comparison expression', function() {
     var e = new Evaluator(grammar);
-    return e.eval(toTree('2 > 1')).should.become(true);
+    e.eval(toTree('2 > 1')).should.equal(true);
   });
   it('should evaluate a false comparison expression', function() {
     var e = new Evaluator(grammar);
-    return e.eval(toTree('2 <= 1')).should.become(false);
+    e.eval(toTree('2 <= 1')).should.equal(false);
   });
   it('should evaluate a complex expression', function() {
     var e = new Evaluator(grammar);
-    return e.eval(toTree('"foo" && 6 >= 6 && 0 + 1 && true'))
-      .should.become(true);
+    e.eval(toTree('"foo" && 6 >= 6 && 0 + 1 && true')).should.equal(true);
   });
   it('should evaluate an identifier chain', function() {
     var context = {foo: {baz: {bar: 'tek'}}},
       e = new Evaluator(grammar, null, context);
-    return e.eval(toTree('foo.baz.bar'))
-      .should.become(context.foo.baz.bar);
+    e.eval(toTree('foo.baz.bar')).should.equal(context.foo.baz.bar);
   });
   it('should apply transforms', function() {
     var context = {foo: 10},
@@ -56,7 +51,7 @@ describe('Evaluator', function() {
         return val / 2;
       },
       e = new Evaluator(grammar, {half: half}, context);
-    return e.eval(toTree('foo|half + 3')).should.become(8);
+    e.eval(toTree('foo|half + 3')).should.equal(8);
   });
   it('should filter arrays', function() {
     var context = {foo: {bar: [
@@ -65,8 +60,7 @@ describe('Evaluator', function() {
         {tok: 'baz'}
       ]}},
       e = new Evaluator(grammar, null, context);
-    return e.eval(toTree('foo.bar[.tek == "baz"]'))
-      .should.eventually.deep.equal([{tek: 'baz'}]);
+    e.eval(toTree('foo.bar[.tek == "baz"]')).should.deep.equal([{tek: 'baz'}]);
   });
   it('should assume array index 0 when traversing', function() {
     var context = {foo: {bar: [
@@ -74,7 +68,7 @@ describe('Evaluator', function() {
         {tek: {hello: 'universe'}}
       ]}},
       e = new Evaluator(grammar, null, context);
-    return e.eval(toTree('foo.bar.tek.hello')).should.become('world');
+    e.eval(toTree('foo.bar.tek.hello')).should.equal('world');
   });
   it('should make array elements addressable by index', function() {
     var context = {foo: {bar: [
@@ -83,31 +77,30 @@ describe('Evaluator', function() {
         {tek: 'foz'}
       ]}},
       e = new Evaluator(grammar, null, context);
-    return e.eval(toTree('foo.bar[1].tek')).should.become('baz');
+    e.eval(toTree('foo.bar[1].tek')).should.equal('baz');
   });
   it('should allow filters to select object properties', function() {
     var context = {foo: {baz: {bar: 'tek'}}},
       e = new Evaluator(grammar, null, context);
-    return e.eval(toTree('foo["ba" + "z"].bar'))
-      .should.become(context.foo.baz.bar);
+    e.eval(toTree('foo["ba" + "z"].bar')).should.equal(context.foo.baz.bar);
   });
   it('should throw when transform does not exist', function() {
     var e = new Evaluator(grammar);
-    return e.eval(toTree('"hello"|world')).should.reject;
+    (function() {
+      e.eval(toTree('"hello"|world'));
+    }).should.throw(Error);
   });
   it('should apply the DivFloor operator', function() {
     var e = new Evaluator(grammar);
-    return e.eval(toTree('7 // 2')).should.become(3);
+    e.eval(toTree('7 // 2')).should.equal(3);
   });
   it('should evaluate an object literal', function() {
     var e = new Evaluator(grammar);
-    return e.eval(toTree('{foo: {bar: "tek"}}'))
-      .should.eventually.deep.equal({foo: {bar: 'tek'}});
+    e.eval(toTree('{foo: {bar: "tek"}}')).should.deep.equal({foo: {bar: 'tek'}});
   });
   it('should evaluate an empty object literal', function() {
     var e = new Evaluator(grammar);
-    return e.eval(toTree('{}'))
-      .should.eventually.deep.equal({});
+    e.eval(toTree('{}')).should.deep.equal({});
   });
   it('should evaluate a transform with multiple args', function() {
     var e = new Evaluator(grammar, {
@@ -115,53 +108,46 @@ describe('Evaluator', function() {
         return val + ": " + a1 + a2 + a3;
       }
     });
-    return e.eval(toTree('"foo"|concat("baz", "bar", "tek")'))
-      .should.become('foo: bazbartek');
+    e.eval(toTree('"foo"|concat("baz", "bar", "tek")')).should.equal('foo: bazbartek');
   });
   it('should evaluate dot notation for object literals', function() {
     var e = new Evaluator(grammar);
-    return e.eval(toTree('{foo: "bar"}.foo')).should.become('bar');
+    e.eval(toTree('{foo: "bar"}.foo')).should.equal('bar');
   });
   it('should allow access to literal properties', function() {
     var e = new Evaluator(grammar);
-    return e.eval(toTree('"foo".length')).should.become(3);
+    e.eval(toTree('"foo".length')).should.equal(3);
   });
   it('should evaluate array literals', function() {
     var e = new Evaluator(grammar);
-    return e.eval(toTree('["foo", 1+2]'))
-      .should.eventually.deep.equal(["foo", 3]);
+    e.eval(toTree('["foo", 1+2]')).should.deep.equal(["foo", 3]);
   });
   it('should apply the "in" operator to strings', function() {
     var e = new Evaluator(grammar);
-    return Promise.all([
-      e.eval(toTree('"bar" in "foobartek"')).should.become(true),
-      e.eval(toTree('"baz" in "foobartek"')).should.become(false)
-    ]);
+    e.eval(toTree('"bar" in "foobartek"')).should.equal(true);
+    e.eval(toTree('"baz" in "foobartek"')).should.equal(false);
+
   });
   it('should apply the "in" operator to arrays', function() {
     var e = new Evaluator(grammar);
-    return Promise.all([
-      e.eval(toTree('"bar" in ["foo","bar","tek"]')).should.become(true),
-      e.eval(toTree('"baz" in ["foo","bar","tek"]')).should.become(false)
-    ]);
+    e.eval(toTree('"bar" in ["foo","bar","tek"]')).should.equal(true);
+    e.eval(toTree('"baz" in ["foo","bar","tek"]')).should.equal(false);
   });
   it('should evaluate a conditional expression', function() {
     var e = new Evaluator(grammar);
-    return Promise.all([
-      e.eval(toTree('"foo" ? 1 : 2')).should.become(1),
-      e.eval(toTree('"" ? 1 : 2')).should.become(2)
-    ]);
+    e.eval(toTree('"foo" ? 1 : 2')).should.equal(1);
+    e.eval(toTree('"" ? 1 : 2')).should.equal(2);
   });
   it('should allow missing consequent in ternary', function() {
     var e = new Evaluator(grammar);
-    return e.eval(toTree('"foo" ?: "bar"')).should.become("foo");
+    e.eval(toTree('"foo" ?: "bar"')).should.equal("foo");
   });
   it('does not treat falsey properties as undefined', function() {
     const e = new Evaluator(grammar);
-    return e.eval(toTree('"".length')).should.become(0);
+    e.eval(toTree('"".length')).should.equal(0);
   });
   it('should handle an expression with arbitrary whitespace', function() {
     var e = new Evaluator(grammar);
-    return e.eval(toTree('(\t2\n+\n3) *\n4\n\r\n')).should.become(20);
+    e.eval(toTree('(\t2\n+\n3) *\n4\n\r\n')).should.equal(20);
   });
 });


### PR DESCRIPTION
This removes support for promises and callbacks. Our benchmarks indicated that the overhead from creating promises was significant. This change combined with the previous change to change the expression tree gives us performance we're now comfortable with in production.

**Benchmark:**
* 5000 iterations.
* Each iteration runs 10 `eval` on 2 distinct rules with a simple context (1 or 2 keys).
* Tried to remove garbage collection during the test so it doesn't impact results. 

Result: 
```
➜  NODE_ENV=production node --max_old_space_size=16400 --max_executable_size=12800 --noconcurrent_sweeping test.js
Original: 7025ms
With cache + sync: 70ms
```

Note that the code now throws on invalid expressions instead of returning a rejected promise. All tests have been updated accordingly. 